### PR TITLE
Credenciales de mongo

### DIFF
--- a/MyMongoLib.js
+++ b/MyMongoLib.js
@@ -6,8 +6,7 @@ const MyMongoLib = function() {
 
   // Connection URL
   const url =
-    process.env.MONGO_URL ||
-    "mongodb+srv://daniel:dard98031160243@amercar-p9oq8.mongodb.net/test?retryWrites=true&w=majority";
+    process.env.MONGO_URL || https://localhost:3000;
 
   // Database Name
   const dbName = "Meraki";


### PR DESCRIPTION
Hola, les propongo no quemar las credenciales de mongo, no es necesario ya que ahi la tienen el llamado a la variable de entorno del servidor. mas bien pongan localhost como segunda opción para cuando lo esten corriendo local